### PR TITLE
Set text size

### DIFF
--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -102,8 +102,9 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean allowFileURLs = call.argument("allowFileURLs");
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean enableAppScheme = call.argument("enableAppScheme");
-        int minFontSize= call.argument("minFontSize");
+        Log.d("flutter", call.arguments + " <<<< text zoom");
         int textZoom = call.argument("textZoom");
+        int minFontSize= call.argument("minFontSize");
         Log.d("flutter", textZoom + " <<<< text zoom");
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -102,7 +102,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean enableAppScheme = call.argument("enableAppScheme");
         int minFontSize= call.argument("minFontSize");
-        int textZoom = 100; //call.argument("textZoom");
+        int textZoom = call.argument("textZoom");
 
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -103,7 +103,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean enableAppScheme = call.argument("enableAppScheme");
         int minFontSize= call.argument("minFontSize");
         int textZoom = call.argument("textZoom");
-
+        Log.d("flutter", textZoom + " <<<< text zoom");
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);
         }

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -102,6 +102,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean enableAppScheme = call.argument("enableAppScheme");
         int minFontSize= call.argument("minFontSize");
+        boolean normalizeTextSize = call.argument("normalizeTextSize");
 
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);
@@ -126,7 +127,8 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
                 appCacheEnabled,
                 allowFileURLs,
                 geolocationEnabled,
-                minFontSize
+                minFontSize,
+                normalizeTextSize
         );
         result.success(null);
     }

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -102,7 +102,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean enableAppScheme = call.argument("enableAppScheme");
         int minFontSize= call.argument("minFontSize");
-        int textZoom = call.argument("textZoom");
+        int textZoom = 100; //call.argument("textZoom");
 
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -7,7 +7,6 @@ import android.graphics.Point;
 import android.view.Display;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -102,10 +101,8 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean allowFileURLs = call.argument("allowFileURLs");
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean enableAppScheme = call.argument("enableAppScheme");
-        Log.d("flutter", call.arguments + " <<<< text zoom");
         int minFontSize= call.argument("minFontSize");
         int textZoom = call.argument("textZoom");
-        Log.d("flutter", textZoom + " <<<< text zoom");
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);
         }

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -7,6 +7,7 @@ import android.graphics.Point;
 import android.view.Display;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Map;

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -103,8 +103,8 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean enableAppScheme = call.argument("enableAppScheme");
         Log.d("flutter", call.arguments + " <<<< text zoom");
-        int textZoom = call.argument("textZoom");
         int minFontSize= call.argument("minFontSize");
+        int textZoom = call.argument("textZoom");
         Log.d("flutter", textZoom + " <<<< text zoom");
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);

--- a/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
+++ b/android/src/main/java/com/flutter_webview_plugin/FlutterWebviewPlugin.java
@@ -102,7 +102,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
         boolean geolocationEnabled = call.argument("geolocationEnabled");
         boolean enableAppScheme = call.argument("enableAppScheme");
         int minFontSize= call.argument("minFontSize");
-        boolean normalizeTextSize = call.argument("normalizeTextSize");
+        int textZoom = call.argument("textZoom");
 
         if (webViewManager == null || webViewManager.closed == true) {
             webViewManager = new WebviewManager(activity, enableAppScheme);
@@ -128,7 +128,7 @@ public class FlutterWebviewPlugin implements MethodCallHandler, PluginRegistry.A
                 allowFileURLs,
                 geolocationEnabled,
                 minFontSize,
-                normalizeTextSize
+                textZoom
         );
         result.success(null);
     }

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -227,7 +227,7 @@ class WebviewManager {
             boolean allowFileURLs,
             boolean geolocationEnabled,
             int minFontSize,
-            boolean normalizeTextSize
+            int textZoom
     ) {
         webView.getSettings().setJavaScriptEnabled(withJavascript);
         webView.getSettings().setBuiltInZoomControls(withZoom);
@@ -241,8 +241,8 @@ class WebviewManager {
 
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
-        if(normalizeTextSize != null && normalizeTextSize) {
-            webView.getSettings().setTextSize(WebSettings.TextSize.NORMAL);
+        if(textZoom) {
+            webView.getSettings().textZoom(textZoom);
         }
         webView.getSettings().setMinimumFontSize(minFontSize);
         webView.getSettings().setMinimumLogicalFontSize(minFontSize);

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -242,7 +242,7 @@ class WebviewManager {
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
 //        if(textZoom) {
-            webView.getSettings().textZoom(100);
+            webView.getSettings().setTextZoom(100);
 //        }
         webView.getSettings().setMinimumFontSize(minFontSize);
         webView.getSettings().setMinimumLogicalFontSize(minFontSize);

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -226,7 +226,8 @@ class WebviewManager {
             boolean appCacheEnabled,
             boolean allowFileURLs,
             boolean geolocationEnabled,
-            int minFontSize
+            int minFontSize,
+            boolean normalizeTextSize
     ) {
         webView.getSettings().setJavaScriptEnabled(withJavascript);
         webView.getSettings().setBuiltInZoomControls(withZoom);
@@ -240,7 +241,9 @@ class WebviewManager {
 
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
-        webView.getSettings().setTextSize(WebSettings.TextSize.NORMAL);
+        if(normalizeTextSize) {
+            webView.getSettings().setTextSize(WebSettings.TextSize.NORMAL);
+        }
         webView.getSettings().setMinimumFontSize(minFontSize);
         webView.getSettings().setMinimumLogicalFontSize(minFontSize);
 

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -240,6 +240,7 @@ class WebviewManager {
 
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
+        webView.getSettings().setTextSize(WebSettings.TextSize.NORMAL);
         webView.getSettings().setMinimumFontSize(minFontSize);
         webView.getSettings().setMinimumLogicalFontSize(minFontSize);
 

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -242,7 +242,7 @@ class WebviewManager {
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
         if(textZoom >= 0) {
-            webView.getSettings().setTextZoom(100);
+            webView.getSettings().setTextZoom(textZoom);
         }
         webView.getSettings().setMinimumFontSize(minFontSize);
         webView.getSettings().setMinimumLogicalFontSize(minFontSize);

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -241,7 +241,7 @@ class WebviewManager {
 
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
-        if(normalizeTextSize) {
+        if(normalizeTextSize != null && normalizeTextSize) {
             webView.getSettings().setTextSize(WebSettings.TextSize.NORMAL);
         }
         webView.getSettings().setMinimumFontSize(minFontSize);

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -241,9 +241,9 @@ class WebviewManager {
 
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
-//        if(textZoom) {
+        if(textZoom >= 0) {
             webView.getSettings().setTextZoom(100);
-//        }
+        }
         webView.getSettings().setMinimumFontSize(minFontSize);
         webView.getSettings().setMinimumLogicalFontSize(minFontSize);
 

--- a/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
+++ b/android/src/main/java/com/flutter_webview_plugin/WebviewManager.java
@@ -241,9 +241,9 @@ class WebviewManager {
 
         webView.getSettings().setAllowFileAccessFromFileURLs(allowFileURLs);
         webView.getSettings().setAllowUniversalAccessFromFileURLs(allowFileURLs);
-        if(textZoom) {
-            webView.getSettings().textZoom(textZoom);
-        }
+//        if(textZoom) {
+            webView.getSettings().textZoom(100);
+//        }
         webView.getSettings().setMinimumFontSize(minFontSize);
         webView.getSettings().setMinimumLogicalFontSize(minFontSize);
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -116,6 +116,7 @@ class FlutterWebviewPlugin {
     bool allowFileURLs,
     bool geolocationEnabled,
     int minFontSize,
+    bool normalizeTextSize,
   }) async {
     final List<String> serializedCookies = cookies?.map((cookie) => cookie.toString())?.toList();
 
@@ -137,6 +138,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
+      'normalizeTextSize' : normalizeTextSize ?? false,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -154,7 +154,6 @@ class FlutterWebviewPlugin {
         'height': rect.height,
       };
     }
-    print(args);
     await _channel.invokeMethod('launch', args);
   }
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -139,7 +139,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
-      'textZoom' : textZoom ?? -1,
+      'textZoom' : 100,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -139,7 +139,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
-      'textZoom' : 100,
+      'textZoom' : textZoom ?? -1,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -154,6 +154,7 @@ class FlutterWebviewPlugin {
         'height': rect.height,
       };
     }
+    print(args);
     await _channel.invokeMethod('launch', args);
   }
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -139,7 +139,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
-      'textZoom' : textZoom,
+      'textZoom' : textZoom ?? -1,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -117,7 +117,7 @@ class FlutterWebviewPlugin {
     bool allowFileURLs,
     bool geolocationEnabled,
     int minFontSize,
-    bool normalizeTextSize,
+    int textZoom,
   }) async {
     final List<String> serializedCookies = cookies?.map((cookie) => cookie.toString())?.toList();
 
@@ -139,7 +139,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
-      'normalizeTextSize' : normalizeTextSize ?? false,
+      'textZoom' : textZoom,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -117,7 +117,7 @@ class FlutterWebviewPlugin {
     bool allowFileURLs,
     bool geolocationEnabled,
     int minFontSize,
-    bool normalizeTextSize = false,
+    bool normalizeTextSize,
   }) async {
     final List<String> serializedCookies = cookies?.map((cookie) => cookie.toString())?.toList();
 
@@ -139,7 +139,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
-      'normalizeTextSize': normalizeTextSize,
+      'normalizeTextSize' : normalizeTextSize ?? false,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -97,6 +97,7 @@ class FlutterWebviewPlugin {
   ///     Allow local files on iOs > 9.0
   /// - [scrollBar]: enable or disable scrollbar
   /// - [minFontSize]: Android only: set minimum font size
+  /// - [normalizeTextSize]: Android only: normalize the font size to disregard os settings.
   Future<Null> launch(String url, {
     Map<String, String> headers,
     bool withJavascript,
@@ -138,7 +139,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
-      'normalizeTextSize' : normalizeTextSize ?? false,
+      'normalizeTextSize': normalizeTextSize ?? false,
     };
 
     if (headers != null) {

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -97,7 +97,7 @@ class FlutterWebviewPlugin {
   ///     Allow local files on iOs > 9.0
   /// - [scrollBar]: enable or disable scrollbar
   /// - [minFontSize]: Android only: set minimum font size
-  /// - [normalizeTextSize]: Android only: normalize the font size to disregard os settings.
+  /// - [textZoom]: Android only: Assign to set the text zoom to a percent. 100 is 100%.
   Future<Null> launch(String url, {
     Map<String, String> headers,
     bool withJavascript,

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -117,7 +117,7 @@ class FlutterWebviewPlugin {
     bool allowFileURLs,
     bool geolocationEnabled,
     int minFontSize,
-    bool normalizeTextSize,
+    bool normalizeTextSize = false,
   }) async {
     final List<String> serializedCookies = cookies?.map((cookie) => cookie.toString())?.toList();
 
@@ -139,7 +139,7 @@ class FlutterWebviewPlugin {
       'allowFileURLs': allowFileURLs ?? false,
       'geolocationEnabled': geolocationEnabled ?? false,
       'minFontSize': minFontSize ?? 1,
-      'normalizeTextSize': normalizeTextSize ?? false,
+      'normalizeTextSize': normalizeTextSize,
     };
 
     if (headers != null) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -32,8 +32,8 @@ class WebviewScaffold extends StatefulWidget {
     this.hidden = false,
     this.initialChild,
     this.allowFileURLs,
-    this.geolocationEnabled
-    this.normalizeTextSize
+    this.geolocationEnabled,
+    this.normalizeTextSize,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -125,7 +125,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               appCacheEnabled: widget.appCacheEnabled,
               allowFileURLs: widget.allowFileURLs,
               geolocationEnabled: widget.geolocationEnabled,
-              normalizeTextSize: widget.normalizeTextSize,
+              normalizeTextSize: wudgetnormalizeTextSize,
             );
           } else {
             if (_rect != value) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -125,7 +125,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               appCacheEnabled: widget.appCacheEnabled,
               allowFileURLs: widget.allowFileURLs,
               geolocationEnabled: widget.geolocationEnabled,
-              normalizeTextSize: wudgetnormalizeTextSize,
+              normalizeTextSize: widget.normalizeTextSize,
             );
           } else {
             if (_rect != value) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -33,6 +33,7 @@ class WebviewScaffold extends StatefulWidget {
     this.initialChild,
     this.allowFileURLs,
     this.geolocationEnabled
+    this.normalizeTextSize
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -57,6 +58,7 @@ class WebviewScaffold extends StatefulWidget {
   final Widget initialChild;
   final bool allowFileURLs;
   final bool geolocationEnabled;
+  final bool normalizeTextSize;
 
   @override
   _WebviewScaffoldState createState() => _WebviewScaffoldState();
@@ -122,7 +124,8 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               supportMultipleWindows: widget.supportMultipleWindows,
               appCacheEnabled: widget.appCacheEnabled,
               allowFileURLs: widget.allowFileURLs,
-              geolocationEnabled: widget.geolocationEnabled
+              geolocationEnabled: widget.geolocationEnabled,
+              normalizeTextSize: widget.normalizeTextSize,
             );
           } else {
             if (_rect != value) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -33,7 +33,7 @@ class WebviewScaffold extends StatefulWidget {
     this.initialChild,
     this.allowFileURLs,
     this.geolocationEnabled,
-    this.normalizeTextSize,
+    this.textZoom,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -58,7 +58,7 @@ class WebviewScaffold extends StatefulWidget {
   final Widget initialChild;
   final bool allowFileURLs;
   final bool geolocationEnabled;
-  final bool normalizeTextSize;
+  final int textZoom;
 
   @override
   _WebviewScaffoldState createState() => _WebviewScaffoldState();
@@ -125,7 +125,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               appCacheEnabled: widget.appCacheEnabled,
               allowFileURLs: widget.allowFileURLs,
               geolocationEnabled: widget.geolocationEnabled,
-              normalizeTextSize: widget.normalizeTextSize,
+              textZoom: widget.textZoom,
             );
           } else {
             if (_rect != value) {


### PR DESCRIPTION
The android webview respects the OS text size settings. This can lead to unintentional scaling issues when depending on font size. 
As a way around this, you can set the web view text zoom value as an int representing the zoom percentage. This branch exposes that functionality to flutter.